### PR TITLE
CLOUD-349 Upgrade-db split

### DIFF
--- a/cmd/percona-dbaas/pxc/upgrade.go
+++ b/cmd/percona-dbaas/pxc/upgrade.go
@@ -15,10 +15,8 @@
 package pxc
 
 import (
-	"bufio"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -87,34 +85,13 @@ var upgradeCmd = &cobra.Command{
 		if len(args) > 1 {
 			oparg = args[1]
 		}
-		operator, appsImg, err := app.Images(oparg, cmd.Flags())
+		appsImg, err := app.Images(oparg, cmd.Flags())
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "[ERROR] setup images for upgrade: %v\n", err)
 			return
 		}
 
-		if operator != "" {
-			num, err := dbservice.Instances("pxc")
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "[ERROR] unable to get pxc instances: %v\n", err)
-			}
-			if len(num) > 1 {
-				sp.Stop()
-				var yn string
-				fmt.Printf("\nFound more than one pxc cluster: %s.\nOperator upgrade may affect other clusters.\nContinue? [y/N] ", num)
-				scanner := bufio.NewScanner(os.Stdin)
-				for scanner.Scan() {
-					yn = strings.TrimSpace(scanner.Text())
-					break
-				}
-				if yn != "y" && yn != "Y" {
-					return
-				}
-				sp.Start()
-			}
-		}
-
-		go dbservice.Upgrade("pxc", app, operator, appsImg, created, msg, cerr)
+		go dbservice.Upgrade("pxc", app, appsImg, created, msg, cerr)
 		sp.Prefix = "Upgrading cluster..."
 
 		for {
@@ -144,8 +121,7 @@ var upgradeCmd = &cobra.Command{
 var envUpgrd *string
 
 func init() {
-	upgradeCmd.Flags().String("operator-image", "", "Custom image to upgrade operator to")
-	upgradeCmd.Flags().String("pxc-image", "", "Custom image to upgrade pxc to")
+	upgradeCmd.Flags().String("database-image", "", "Custom image to upgrade pxc to")
 	upgradeCmd.Flags().String("proxysql-image", "", "Custom image to upgrade proxySQL to")
 	upgradeCmd.Flags().String("backup-image", "", "Custom image to upgrade backup to")
 	envUpgrd = upgradeCmd.Flags().String("environment", "", "Target kubernetes cluster")

--- a/dbaas/psmdb/psmdb.go
+++ b/dbaas/psmdb/psmdb.go
@@ -153,25 +153,16 @@ func (p *PSMDB) Upgrade(crRaw []byte, newImages map[string]string) error {
 
 const operatorImage = "percona/percona-server-mongodb-operator:"
 
-func (p *PSMDB) Images(ver string, f *pflag.FlagSet) (operator string, apps map[string]string, err error) {
+func (p *PSMDB) Images(ver string, f *pflag.FlagSet) (apps map[string]string, err error) {
 	apps = make(map[string]string)
 	if ver != "" {
-		operator = operatorImage + ver
 		apps["psmdb"] = operatorImage + ver + "-mongod4.0"
 		apps["backup"] = operatorImage + ver + "-backup"
 	}
 
-	op, err := f.GetString("operator-image")
+	psmdb, err := f.GetString("database-image")
 	if err != nil {
-		return operator, apps, errors.New("undefined `operator-image`")
-	}
-	if op != "" {
-		operator = op
-	}
-
-	psmdb, err := f.GetString("psmdb-image")
-	if err != nil {
-		return operator, apps, errors.New("undefined `psmdb-image`")
+		return apps, errors.New("undefined `database-image`")
 	}
 	if psmdb != "" {
 		apps["psmdb"] = psmdb
@@ -179,13 +170,13 @@ func (p *PSMDB) Images(ver string, f *pflag.FlagSet) (operator string, apps map[
 
 	backup, err := f.GetString("backup-image")
 	if err != nil {
-		return operator, apps, errors.New("undefined `backup-image`")
+		return apps, errors.New("undefined `backup-image`")
 	}
 	if backup != "" {
 		apps["backup"] = backup
 	}
 
-	return operator, apps, nil
+	return apps, nil
 }
 
 func (p *PSMDB) OperatorName() string {

--- a/dbaas/pxc/pxc.go
+++ b/dbaas/pxc/pxc.go
@@ -147,27 +147,18 @@ func (p *PXC) Upgrade(crRaw []byte, newImages map[string]string) error {
 
 const operatorImage = "percona/percona-xtradb-cluster-operator:"
 
-func (p *PXC) Images(ver string, f *pflag.FlagSet) (operator string, apps map[string]string, err error) {
+func (p *PXC) Images(ver string, f *pflag.FlagSet) (apps map[string]string, err error) {
 	apps = make(map[string]string)
 
 	if ver != "" {
-		operator = operatorImage + ver
 		apps["pxc"] = operatorImage + ver + "-pxc"
 		apps["proxysql"] = operatorImage + ver + "-proxysql"
 		apps["backup"] = operatorImage + ver + "-backup"
 	}
 
-	op, err := f.GetString("operator-image")
+	pxc, err := f.GetString("database-image")
 	if err != nil {
-		return operator, apps, errors.New("undefined `operator-image`")
-	}
-	if op != "" {
-		operator = op
-	}
-
-	pxc, err := f.GetString("pxc-image")
-	if err != nil {
-		return operator, apps, errors.New("undefined `pxc-image`")
+		return apps, errors.New("undefined `database-image`")
 	}
 	if pxc != "" {
 		apps["pxc"] = pxc
@@ -175,7 +166,7 @@ func (p *PXC) Images(ver string, f *pflag.FlagSet) (operator string, apps map[st
 
 	proxysql, err := f.GetString("proxysql-image")
 	if err != nil {
-		return operator, apps, errors.New("undefined `proxysql-image`")
+		return apps, errors.New("undefined `proxysql-image`")
 	}
 	if proxysql != "" {
 		apps["proxysql"] = proxysql
@@ -183,13 +174,13 @@ func (p *PXC) Images(ver string, f *pflag.FlagSet) (operator string, apps map[st
 
 	backup, err := f.GetString("backup-image")
 	if err != nil {
-		return operator, apps, errors.New("undefined `backup-image`")
+		return apps, errors.New("undefined `backup-image`")
 	}
 	if backup != "" {
 		apps["backup"] = backup
 	}
 
-	return operator, apps, nil
+	return apps, nil
 }
 
 func (p *PXC) OperatorName() string {

--- a/e2e-tests/psmdb/run
+++ b/e2e-tests/psmdb/run
@@ -117,9 +117,11 @@ list() {
 
 upgrade() {
     desc upgrading psmdb cluster
+
+    percona-dbaas --demo psmdb upgrade-operator "${CLUSTER}" --operator-image "${OPERATOR_IMAGE_TO_UPDATE}" 
+
     percona-dbaas --demo psmdb upgrade-db "${CLUSTER}" master \
-                  --operator-image "${OPERATOR_IMAGE_TO_UPDATE}" \
-                  --psmdb-image "${PSMDB_IMAGE_TO_UPDATE}" \
+                  --database-image "${PSMDB_IMAGE_TO_UPDATE}" \
                   --backup-image "${BACKUP_IMAGE_TO_UPDATE}"
 
 

--- a/e2e-tests/pxc/run
+++ b/e2e-tests/pxc/run
@@ -89,10 +89,12 @@ list() {
 
 upgrade() {
 	desc upgrading pxc cluster
+
+	percona-dbaas --demo pxc upgrade-operator "${CLUSTER}" --operator-image "${OPERATOR_IMAGE_TO_UPDATE}"
+
 	percona-dbaas --demo pxc upgrade-db "${CLUSTER}" master \
-				  --operator-image "${OPERATOR_IMAGE_TO_UPDATE}" \
 				  --proxysql-image "${PROXYSQL_IMAGE_TO_UPDATE}" \
-				  --pxc-image "${PXC_IMAGE_TO_UPDATE}"
+				  --database-image "${PXC_IMAGE_TO_UPDATE}"
 
 
 	sleep 10


### PR DESCRIPTION
Since the spec https://confluence.percona.com/display/CLOUD/Operator+CLI+Tool
    states that operator shall be upgraded by the explicit command
    upgrade-db has to be modified accordingly.