### PR TITLE
Fix tests on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,14 +31,12 @@ void popArtifactFile(String FILE_NAME) {
 void runTest(String TEST_NAME, String CLUSTER_PREFIX) {
     popArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$TEST_NAME")
     sh """
-        if [ -f "$GIT_BRANCH-$GIT_SHORT_COMMIT-$TEST_NAME" ]; then
+         if [ -f "$GIT_BRANCH-$GIT_SHORT_COMMIT-$TEST_NAME" ]; then
             echo Skip $TEST_NAME test
         else
-            HOMETEMP=$(mktemp)
-            mkdir $HOMETEMP/.kube
-            ln -s /tmp/$CLUSTER_NAME-${CLUSTER_PREFIX} $HOMETEMP/.kube/config
+            export KUBECONFIG=/tmp/$CLUSTER_NAME-${CLUSTER_PREFIX}
             source $HOME/google-cloud-sdk/path.bash.inc
-            HOME=$HOMETEMP ./e2e-tests/$TEST_NAME/run
+            ./e2e-tests/$TEST_NAME/run
             touch $GIT_BRANCH-$GIT_SHORT_COMMIT-$TEST_NAME
         fi
     """

--- a/dbaas/dbaas.go
+++ b/dbaas/dbaas.go
@@ -90,15 +90,16 @@ func New(environment string) (*Cmd, error) {
 
 	}
 	return &Cmd{
-		environment: os.Getenv("HOME") + "/.kube/" + "/config",
+		environment: "",
 	}, nil
 }
 
 func (p Cmd) runCmd(cmd string, args ...string) ([]byte, error) {
 	cli := exec.Command(cmd, args...)
 	cli.Env = os.Environ()
-	cli.Env = append(cli.Env, "KUBECONFIG="+p.environment)
-
+	if len(p.environment) > 0 {
+		cli.Env = append(cli.Env, "KUBECONFIG="+p.environment)
+	}
 	o, err := cli.CombinedOutput()
 	if err != nil {
 		return nil, ErrCmdRun{cmd: cmd, args: args, output: o}


### PR DESCRIPTION
Previos CLI logic assumed that kubeconfig will be
available at HOME/.kube/config or HOME/.percona/<env> without
taking into account KUBECONFIG external env variable. Now it
will be included.